### PR TITLE
Fix broken build due to name change

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -149,10 +149,18 @@ const connectAuthorsToPosts = (getNode, getNodes, createNodeField) => {
 
     // Add author information to each post
     postNodes.forEach(post => {
-        const { authors = [] } = post.frontmatter;
+        const { authors = [], title } = post.frontmatter;
 
         const enrichedAuthors = authors.map(author => {
             const match = authorNodes.find(node => author === node.frontmatter.title);
+            if (!match) {
+                console.error(
+                    `Author not found! The author for the post "${title}" was set to "${author}", but there is no such author. This will typically happen if the author updates their name. To fix this, please check the author file for the author(s) in question and change the name in the post accordingly.`
+                );
+                throw new Error(
+                    "Could not build, because there was a post that didn't have a matching author name. See logs for more info."
+                );
+            }
             return match.frontmatter;
         });
 

--- a/post/javascript/coercion-and-equality-checks.md
+++ b/post/javascript/coercion-and-equality-checks.md
@@ -16,7 +16,7 @@ links:
     url: >-
       https://github.com/getify/You-Dont-Know-JS/blob/master/types%20%26%20grammar/ch4.md#loose-equals-vs-strict-equals
 authors:
-  - Nicolai Hagen
+  - Nicolai August Hagen
 ---
 ## Coercion
 Typecasting. Converting. Coercion. We tend to have many names for the things we love. Coercion in JavaScript is really just about converting one value to another. For example, `5 + ''` will _convert_ the number 5 to a string. If we assign this expression to a variable (or wrap the expression in parentheses), we will suddenly have available methods from the string prototype. For example, we can retrieve the field `.length`.

--- a/post/javascript/dont-break-the-web.md
+++ b/post/javascript/dont-break-the-web.md
@@ -15,7 +15,7 @@ links:
   - title: Read about the history API over at MDN
     url: 'https://developer.mozilla.org/en-US/docs/Web/API/History'
 authors:
-  - Nicolai Hagen
+  - Nicolai August Hagen
 ---
 Many years have passed since your (grand) parents surfed the web with Netscape Navigator, or Internet Explorer was actually used by the people of the web.
 Browsers have not always had the same version, and neither have the various web standards.


### PR DESCRIPTION
Turns out, you can't change the author name without re-setting the
authors for every post they have written.

This commit adds a log statement and throws an error explaining this
for future debuggers.