### PR TITLE
Remove the flash when loading the page in dark mode

### DIFF
--- a/src/components/GlobalStyles.js
+++ b/src/components/GlobalStyles.js
@@ -28,9 +28,10 @@ const GlobalStyles = createGlobalStyle(
 
     background: #ffffff;
     color: #0e0e0e;
+    
     ${mediaQueries.darkMode} {
       background: #0e0e0e;
-      color: #ffffff;      
+      color: #ffffff;
     }
   }
   

--- a/src/components/ThemeContext.js
+++ b/src/components/ThemeContext.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import * as colors from '../constants/colors';
+import * as mediaQueries from '../constants/media-queries';
 
 const ThemeContext = React.createContext(null);
 

--- a/src/constants/media-queries.js
+++ b/src/constants/media-queries.js
@@ -1,4 +1,4 @@
 export const largeUp = '@media all and (min-width: 1008px)';
 export const mediumUp = '@media all and (min-width: 800px)';
 export const smallUp = '@media all and (min-width: 420px)';
-export const darkMode = '@media (prefers-color-scheme: dark)';
+export const darkMode = '@media all and (prefers-color-scheme: dark)';


### PR DESCRIPTION
This is a bad workaround, but it works around the issue by just skipping the "client needs to figure out what media query is matching first" phase, and just using the correct colors from the get go.