### PR TITLE
Feat: Lenke til samleside for kalendere som en del av footer

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -75,7 +75,9 @@ const SiteFooter = ({ calendarName }) => {
     return (
         <Container>
             <Column>
-                <h2 style={{ marginTop: 0 }}>Bekk Christmas</h2>
+                <h2 style={{ marginTop: 0 }}>
+                    <a href="https://bekk.christmas">Bekk Christmas</a>
+                </h2>
                 <FlatList>
                     {otherCalendars.map(calendar => (
                         <li key={calendar}>


### PR DESCRIPTION
Savnet en lenke fra hver enkelt fagområde sin kalender tilbake til samlesiden bekk.christmas.
Endrer det gjerne til å være en lenke sist i listen over de andre kalenderne hvis det passer
bedre.

![image](https://user-images.githubusercontent.com/9053627/70210130-30a2ca00-1732-11ea-8a94-dae51b14657e.png)
