### PR TITLE
La til max-width på wide-image for å få det til å fungere igjen

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -30,6 +30,7 @@ const MainContent = styled(MainContentWrapper)`
 
     .wide-image {
         width: 100%;
+        max-width: 1600px;
         height: 400px;
         object-fit: cover;
     }


### PR DESCRIPTION
Brakk wide-image med sist endring 😅 
Dette skal løse biffen. 

Testcase https://preview.bekk.christmas/ux/2019/6

Kan eventuelt ha max-width:none;