### PR TITLE
Improve post-december bekk.christmas

### DIFF
--- a/src/components/CalendarWindowOpen.js
+++ b/src/components/CalendarWindowOpen.js
@@ -38,9 +38,11 @@ const CalendarWindowOpen = ({ to, href, imageUrl, title, calendarName }) => {
         <>
             <img src={imageUrl} alt="" />
             {calendarName && <CalendarName>{mapCalendarToName(calendarName)}</CalendarName>}
-            <CalendarWindowDescription hasMargin={calendarName != null}>
-                {title}
-            </CalendarWindowDescription>
+            {title && (
+                <CalendarWindowDescription hasMargin={calendarName != null}>
+                    {title}
+                </CalendarWindowDescription>
+            )}
         </>
     );
     if (to) {

--- a/src/templates/frontpage.js
+++ b/src/templates/frontpage.js
@@ -96,6 +96,7 @@ const Top = styled.div`
 const Frontpage = ({ data, pageContext }) => {
     const calendars = data.allMarkdownRemark.nodes.map(markdown => markdown.frontmatter);
     const showTeaser = calendars.length === 0;
+    const isDecember = new Date().getMonth() === 11;
 
     if (showTeaser) {
         return (
@@ -149,7 +150,9 @@ const Frontpage = ({ data, pageContext }) => {
                     <img src={treeImage} alt="" />
                 </ChristmasTreeDesktop>
             </Top>
-            <DailyWindowHeader>Today's articles</DailyWindowHeader>
+            <DailyWindowHeader>
+                {isDecember ? "Today's articles" : 'Our calendars'}
+            </DailyWindowHeader>
             <Calendar>
                 {calendars.map(calendar => (
                     <li key={calendar.calendar}>
@@ -169,7 +172,8 @@ const Frontpage = ({ data, pageContext }) => {
                                     pageContext.isPreview,
                                     calendar.calendar,
                                     calendar.post_year,
-                                    calendar.post_day
+                                    calendar.post_day,
+                                    isDecember
                                 )
                             }
                             imageUrl={getWindowImagePlaceholder(
@@ -178,7 +182,7 @@ const Frontpage = ({ data, pageContext }) => {
                                 calendar.post_year
                             )}
                             calendarName={calendar.calendar}
-                            title={calendar.title}
+                            title={isDecember && calendar.title}
                         />
                     </li>
                 ))}

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,13 +98,17 @@ export const mapCalendarToName = calendar => {
     }
 };
 
-export const getCalendarPostLink = (isPreview, calendar, year, day) => {
+export const getCalendarPostLink = (isPreview, calendar, year, day, forceFrontPage = false) => {
     let link = '';
 
     if (isPreview) {
         link = `/${calendar}`;
     } else {
         link = `https://${calendar}.christmas`;
+    }
+
+    if (forceFrontPage) {
+        return link;
     }
 
     if (!day) {


### PR DESCRIPTION
Kjappeste måte å få ting til å se... "ok" ut om folk stikker innom bekk.christmas nå på nyåret.

![image](https://user-images.githubusercontent.com/1307267/71672536-8f318700-2d76-11ea-836a-d2eb9684eb5c.png)

TL;DR: 

- Endre "Today's articles" til "Our calendars"
- Fjerne artikkelnavnet
- Lenke til landingssiden for hver kalender