### PR TITLE
Create redirects for the root pages

### DIFF
--- a/src/templates/redirect.js
+++ b/src/templates/redirect.js
@@ -1,5 +1,6 @@
 import { useNavigate } from '@reach/router';
 import { useEffect } from 'react';
+
 const RedirectTemplate = ({ pageContext }) => {
     const navigate = useNavigate();
     useEffect(() => {


### PR DESCRIPTION
Jeg er litt usikker på om dette fungerer som forventet, men jeg gjerne få litt flere øyne på den. Det fungerer lokalt i dev, men ikke lokalt når jeg bygger. Lurer på om det er en cache som gjør at det ikke fungerer når jeg bygger, så dra gjerne ned selv og ta en titt.

Dette redirecter f.eks. react.christmas til react.christmas/2020.

Problemet jeg opplever lokalt er at alt redirecter tilbake til `/` av en eller annen grunn.