### PR TITLE
Legg til gatsby-remark-numbered-footnotes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,6 +49,7 @@ module.exports = {
                         },
                     },
                     `gatsby-remark-emoji`,
+                    `gatsby-remark-numbered-footnotes`,
                 ],
             },
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8640,6 +8640,14 @@
         "emojione": "^3.1.2"
       }
     },
+    "gatsby-remark-numbered-footnotes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-numbered-footnotes/-/gatsby-remark-numbered-footnotes-1.0.1.tgz",
+      "integrity": "sha512-eqb/vxhniIASyoNYRbATpHVD1owtRAM2vTLyUJTz5pe3RugU99n1xNyeYHeg6eb98iyoWi2EaEskI4+reytN4A==",
+      "requires": {
+        "remark-numbered-footnotes": "^1.0.1"
+      }
+    },
     "gatsby-remark-prismjs": {
       "version": "3.5.11",
       "resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.5.11.tgz",
@@ -16411,6 +16419,14 @@
         "mdast-comment-marker": "^1.0.0",
         "unified-message-control": "^1.0.0",
         "xtend": "^4.0.1"
+      }
+    },
+    "remark-numbered-footnotes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-numbered-footnotes/-/remark-numbered-footnotes-1.1.0.tgz",
+      "integrity": "sha512-1clY6IdWs3Ppv/IsdEVzvM9HxUNDkIicEU0lhdqmxDv2I/qaqDufSYSXmtsNti7j8/B1z93WamT6iDWGzkiTpA==",
+      "requires": {
+        "unist-util-visit": "^1.3.1"
       }
     },
     "remark-parse": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "gatsby-plugin-react-helmet": "^3.3.10",
         "gatsby-plugin-styled-components": "^3.3.10",
         "gatsby-remark-emoji": "0.0.3",
+        "gatsby-remark-numbered-footnotes": "^1.0.1",
         "gatsby-remark-prismjs": "^3.5.11",
         "gatsby-remark-responsive-iframe": "^2.4.12",
         "gatsby-source-filesystem": "^2.3.27",


### PR DESCRIPTION
Legger til [gatsby-remark-numbered-footnotes ](https://github.com/jlengstorf/gatsby-remark-numbered-footnotes) som endrer fotnoter til å bli automatisk navngitt i numberert rekke følge. Se readmen på github for prosjektet for eksempler.

Jeg ønsker at fotnotene skal være nummererte, men det er slitsom å oppdatere nummerene hvis jeg legger til en ny tidligere i artikkelen. Denne pluginen gjør at man kan kalle fotnote-linken hva enn man ønsker og ved rendring blir de automatisk endret til å være nummerert.

Dette vil gjøre at man ikke får har custom fotnote-lenkenavn i den rendrede artikkelen og kan jo være noe andre egentlig ønsker, men jeg håper denne kan merges.

Vet dere om det finnes en enkel måte å sjekke om det påvirker noen artikler?