### PR TITLE
Remove and from string if there is only one previous calendar

### DIFF
--- a/src/components/RelatedCalendars.js
+++ b/src/components/RelatedCalendars.js
@@ -18,7 +18,7 @@ export const RelatedCalendars = ({ paths }) => {
             Want more? Check out the calendar{paths.length > 1 && 's'} from{' '}
             {paths.map((path, index) => (
                 <>
-                    {index === paths.length - 1 && ' and '}
+                    {index === paths.length - 1 && index !== 0 && ' and '}
                     <Link key={path} to={path}>
                         {path.split('/').pop()}
                     </Link>


### PR DESCRIPTION
There's a teeny tiny bug on the "previous calendars" line when there is only one previous year of the calendar. Here's an example from https://ux.christmas/2020
![Screenshot 2020-12-04 at 10 17 01](https://user-images.githubusercontent.com/14059677/101146166-f86ee980-361a-11eb-9239-151718d7aa7e.png)
This change seems to fix that without breaking the other calendars