### PR TITLE
Add support for canonical URLs

### DIFF
--- a/studio/schemas/documents/post.js
+++ b/studio/schemas/documents/post.js
@@ -76,6 +76,12 @@ const post = {
       },
     },
     {
+      name: 'canonicalUrl',
+      type: 'url',
+      title: 'Canonical URL',
+      description: 'If the URL was posted elsewhere, please specify the original (canonical) url here.',
+    },
+    {
       title: "Description",
       description:
         "This is the excerpt, shown at the top of the page, as well as when shared on social media.",

--- a/web/features/site-metadata/SiteMetadata.tsx
+++ b/web/features/site-metadata/SiteMetadata.tsx
@@ -7,6 +7,7 @@ type SiteMetadataProps = {
   keywords?: string[];
   image?: string;
   author?: string;
+  canonicalUrl?: string;
 };
 export const SiteMetadata = ({
   title,
@@ -14,6 +15,7 @@ export const SiteMetadata = ({
   keywords = ["bekk", "christmas", "technology", "design", "strategy"],
   image = "https://cdn.sanity.io/images/ah2n1vfr/production/b13a686723a264260182df3e79b1b94b4f766b35-1440x879.png?w=1200",
   author = "Bekk",
+  canonicalUrl,
 }: SiteMetadataProps) => {
   const router = useRouter();
 
@@ -35,6 +37,8 @@ export const SiteMetadata = ({
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:site" content="@livetibekk" />
       <meta name="twitter:creator" content="@livetibekk" />
+
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     </Head>
   );
 };

--- a/web/pages/post/[year]/[day]/[slug]/index.tsx
+++ b/web/pages/post/[year]/[day]/[slug]/index.tsx
@@ -54,6 +54,7 @@ export default function PostPage({
         description={toPlainText(post.description)}
         image={getImageUrl(post.coverImage)}
         author={authors.map((author) => author.fullName).join(", ")}
+        canonicalUrl={post.canonicalUrl}
       />
       <Article
         backButtonHref={`/post/${availableFromDate.getFullYear()}/${availableFromDate.getDate()}`}
@@ -166,6 +167,7 @@ type Post = {
   embedUrl?: string;
   podcastLength?: number;
   slug: string;
+  canonicalUrl?: string;
   title: string;
   description: unknown[];
   content: unknown[];


### PR DESCRIPTION
Some content we publish, has already been published elsewhere. If that's the case, we want to hint Google to the correct place