### PR TITLE
Add option for specifying the max width of an image

### DIFF
--- a/studio/schemas/objects/imageWithMetadata.js
+++ b/studio/schemas/objects/imageWithMetadata.js
@@ -20,6 +20,17 @@ export default {
       },
     },
     {
+      name: "maxWidth",
+      title: "Max width",
+      description:
+        'If you for some reason want to set a custom max width for the image, specify it in pixels here (ex. "500" - skip the "px").',
+      type: "number",
+      validation: (Rule) => Rule.min(0).max(1200),
+      options: {
+        isHighlighted: true,
+      },
+    },
+    {
       name: "alt",
       type: "string",
       title: "Alternative text",

--- a/web/features/portable-text/serializers/ImageBlock.tsx
+++ b/web/features/portable-text/serializers/ImageBlock.tsx
@@ -1,6 +1,4 @@
-import { Image } from "@chakra-ui/image";
-import { Text } from "@chakra-ui/layout";
-import { Stack } from "@chakra-ui/react";
+import { Image, Stack, Text } from "@chakra-ui/react";
 import * as React from "react";
 import { urlFor } from "../../../utils/sanity/utils";
 
@@ -13,8 +11,17 @@ export const ImageBlock = ({ node }: any) => {
     <Stack as="figure">
       <Image
         src={urlFor(node.asset).width(800).url()!}
-        srcSet={`${urlFor(node.asset).width(400).url()!} 400w, ${urlFor(node.asset).width(800).url()!} 800w, ${urlFor(node.asset).width(1200).url()!} 1200w, ${urlFor(node.asset).width(1600).url()!} 1600w`}
+        srcSet={`${urlFor(node.asset).width(400).url()!} 400w, ${urlFor(
+          node.asset
+        )
+          .width(800)
+          .url()!} 800w, ${urlFor(node.asset)
+          .width(1200)
+          .url()!} 1200w, ${urlFor(node.asset).width(1600).url()!} 1600w`}
         sizes="(max-width: 920px) 100vw, 920px"
+        maxWidth={node.maxWidth ? `${node.maxWidth}px` : "100%"}
+        mx="auto"
+        display="block"
         alt={node.alt}
         borderRadius={20}
       />


### PR DESCRIPTION
Sometimes, images just need to be smaller than we default to. Therefore, you can now specify a max width for a given image.