### PR TITLE
Remove Christmas miracle from hype button

### DIFF
--- a/web/features/hype/HypeButton.tsx
+++ b/web/features/hype/HypeButton.tsx
@@ -11,7 +11,7 @@ import { Package } from "./Package";
 import { useHype } from "./useHype";
 
 export const HypeButton = (props: BoxProps) => {
-  const { serverHype, addHype } = useHype();
+  const { serverHype, addHype, myAddedHype } = useHype();
   const [addedHype, setAddedHype] = React.useState(0);
   const [isAddingHype, setAddingHype] = React.useState(false);
   const [whatToShow, setWhatToShow] = React.useState<"added" | "total">(
@@ -38,9 +38,12 @@ export const HypeButton = (props: BoxProps) => {
   const onPointerReleased = () => {
     clearInterval(intervalRef.current);
     setAddingHype(false);
+    clearInterval(timeoutRef.current);
     timeoutRef.current = setTimeout(async () => {
       if (!isMaxedOut) {
-        await addHype(addedHype);
+        // Only add the hype we haven't already submitted
+        const hypeToAdd = addedHype - myAddedHype;
+        await addHype(Math.min(Math.max(hypeToAdd, 0), 50));
       }
       setWhatToShow("total");
       setMaxedOut(addedHype === 50);

--- a/web/features/hype/useHype.ts
+++ b/web/features/hype/useHype.ts
@@ -6,6 +6,7 @@ export const useHype = () => {
   const router = useRouter();
   const slug = slugify(router.asPath.split("?")[0]);
   const [serverHype, setServerHype] = useState(0);
+  const [myAddedHype, setMyAddedHype] = useState(0);
 
   const fetchHype = React.useCallback(async () => {
     const response = await fetch(`/api/${slug}/hype`);
@@ -20,6 +21,7 @@ export const useHype = () => {
 
   const addHype = async (hypeToAdd: number) => {
     try {
+      setMyAddedHype((prev) => prev + hypeToAdd);
       await fetch(`/api/${slug}/hype`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -31,5 +33,5 @@ export const useHype = () => {
     }
   };
 
-  return { serverHype, addHype };
+  return { serverHype, addHype, myAddedHype };
 };


### PR DESCRIPTION
This fixes hype inflation on bekk.christmas:

- Clears onPointerReleased timeout before starting a new one so we don't submit multiple times
- Only submits the additional hypes we accumulated since last submit